### PR TITLE
Add --update-all option that updates all anime on user's list

### DIFF
--- a/anime_downloader/cli.py
+++ b/anime_downloader/cli.py
@@ -1,4 +1,4 @@
-import click
+﻿import click
 import sys
 import os
 
@@ -117,25 +117,29 @@ def dl(ctx, anime_url, episode_range, url, player, skip_download, quality,
     '--remove', '-r', 'remove', type=bool, is_flag=True,
     help="Remove the specified anime")
 @click.option(
+    '--update-all', '-u', 'update_all', type=bool, is_flag=True,
+    help="Update the episodes of all anime in your list"
+)
+@click.option(
     '--quality', '-q', type=click.Choice(['360p', '480p', '720p', '1080p']),
     help='Specify the quality of episode.')
 @click.option(
     '--download-dir', metavar='PATH',
-    help="Specifiy the directory to download to")
+    help="Specify the directory to download to")
 @click.option(
     '--log-level', '-ll', 'log_level',
     type=click.Choice(['DEBUG', 'INFO', 'WARNING', 'ERROR']),
     help='Sets the level of logger', default='INFO')
-def watch(anime_name, new, _list, quality, log_level, remove, download_dir):
+def watch(anime_name, new, update_all, _list, quality, log_level, remove, download_dir):
     """
     With watch you can keep track of any anime you watch.
 
     Available Commands after selection of an anime:\n
-    set      : set episodes_done and title. Ex: set episodes_done=3\n
-    remove   : remove selected anime from watch list\n
-    update   : Update the episodes of the currrent anime\n
-    watch    : Watch selected anime\n
-    download : Download episodes of selected anime
+    set        : set episodes_done and title. Ex: set episodes_done=3\n
+    remove     : remove selected anime from watch list\n
+    update     : Update the episodes of the currrent anime\n
+    watch      : Watch selected anime\n
+    download   : Download episodes of selected anime
     """
     util.setup_logger(log_level)
     util.print_info(__version__)
@@ -164,6 +168,11 @@ def watch(anime_name, new, _list, quality, log_level, remove, download_dir):
                           "Use a better search term.".format(anime_name))
             sys.exit(1)
         sys.exit(0)
+
+    if update_all:
+        animes = watcher.anime_list()
+        for anime in animes:
+            watcher.update_anime(anime)
 
     if _list:
         list_animes(watcher, quality, download_dir)

--- a/anime_downloader/watch.py
+++ b/anime_downloader/watch.py
@@ -1,4 +1,4 @@
-from anime_downloader import config
+﻿from anime_downloader import config
 from anime_downloader.sites.nineanime import NineAnime
 
 import os
@@ -42,6 +42,16 @@ class Watcher:
             click.echo(fmt_str.format(idx+1, anime.title,
                                       *anime.progress(),
                                       meta=meta.get('Type', '')))
+
+    def anime_list(self):
+        # Stores list of anime names in watcher's list
+        anime_names = []
+        animes = self._read_from_watch_file()
+
+        for idx, anime_name in enumerate(animes):
+            anime_names.append(anime_name)
+        
+        return anime_names
 
     def get(self, anime_name):
         animes = self._read_from_watch_file()

--- a/anime_downloader/watch.py
+++ b/anime_downloader/watch.py
@@ -45,13 +45,7 @@ class Watcher:
 
     def anime_list(self):
         # Stores list of anime names in watcher's list
-        anime_names = []
-        animes = self._read_from_watch_file()
-
-        for idx, anime_name in enumerate(animes):
-            anime_names.append(anime_name)
-        
-        return anime_names
+        return self._read_from_watch_file()
 
     def get(self, anime_name):
         animes = self._read_from_watch_file()


### PR DESCRIPTION
This adds an option to "anime watch" (`--update-all, -u`) that updates all the anime on the user's list at once. It was just kinda annoying to update them one by one. In the future, this should only update anime that is currently airing so that you don't have to wait for every single thing on your list to update. My list is relatively small so it isn't a problem, but I can see the wait being annoying for someone with a larger list.

In order to do this I added a method called "anime_list" to the Watcher class, which returns the names of all the anime in the user's list, just to make things look a bit nicer in `cli.py`. However, it does feel kind of redundant. 

This also fixes a minor spelling mistake. "Specify" was spelled as "Specifiy" in line 46 of `cli.py`