### PR TITLE
Only update anime if it's status is "airing", Show number of retry attempts

### DIFF
--- a/anime_downloader/cli.py
+++ b/anime_downloader/cli.py
@@ -280,7 +280,7 @@ def watch_anime(watcher, anime):
             if returncode == mpv.STOP:
                 sys.exit(0)
             elif returncode == mpv.CONNECT_ERR:
-                logging.warning("Couldn't connect. Retrying.")
+                logging.warning("Couldn't connect. Retrying. Attempt #{}".format(tries+1))
                 continue
             anime.episodes_done += 1
             watcher.update(anime)

--- a/anime_downloader/sites/nineanime.py
+++ b/anime_downloader/sites/nineanime.py
@@ -155,7 +155,7 @@ def a(t, e):
 
 
 def generate_(data):
-    DD = "iQDWcsGqN"
+    DD = "bVZX0bdD"
     param_ = s(DD)
 
     for key, value in data.items():

--- a/anime_downloader/watch.py
+++ b/anime_downloader/watch.py
@@ -44,7 +44,6 @@ class Watcher:
                                       meta=meta.get('Type', '')))
 
     def anime_list(self):
-        # Stores list of anime names in watcher's list
         return self._read_from_watch_file()
 
     def get(self, anime_name):
@@ -63,13 +62,14 @@ class Watcher:
             return anime
 
     def update_anime(self, anime):
-        logging.info('Updating anime {}'.format(anime.title))
-        newanime = AnimeInfo(anime.url, episodes_done=anime.episodes_done,
-                             timestamp=time())
-        newanime.title = anime.title
+        if anime.meta['Status'].lower() == 'airing':
+            logging.info('Updating anime {}'.format(anime.title))
+            newanime = AnimeInfo(anime.url, episodes_done=anime.episodes_done,
+                                timestamp=time())
+            newanime.title = anime.title
 
-        self.update(newanime)
-        return newanime
+            self.update(newanime)
+            return newanime
 
     def add(self, anime):
         self._append_to_watch_file(anime)


### PR DESCRIPTION
`update_anime` will only update anime on the list that is marked as "airing".
Also changed log warning under `watch_anime` function in `cli.py` to display which try they're currently on