### PR TITLE
Fix KissAnime returning list of episodes of a show rather than the show itself when searching

### DIFF
--- a/anime_downloader/sites/kissanime.py
+++ b/anime_downloader/sites/kissanime.py
@@ -59,6 +59,13 @@ class Kissanime(BaseAnimeCF):
 
         soup = BeautifulSoup(res.text, 'html.parser')
 
+        if soup.title.text.strip().lower() != "find anime":
+            return [SearchResult(
+                title=soup.find('a', 'bigChar').text,
+                url='https://kissanime.ru'+soup.find('a', 'bigChar').get('href'),
+                poster='',
+            )]
+
         searched = [s for i, s in enumerate(soup.find_all('td')) if not i % 2]
 
         ret = []


### PR DESCRIPTION
This will make the search method under `kissanime.py` just display the show as a single search result rather than listing the episodes of the show.

Closes #18 