### PR TITLE
Filter out specials and other and fix watch

### DIFF
--- a/anime_downloader/sites/kissanime.py
+++ b/anime_downloader/sites/kissanime.py
@@ -83,6 +83,12 @@ class Kissanime(BaseAnimeCF):
     def _getEpisodeUrls(self, soup):
         ret = soup.find('table', {'class': 'listing'}).find_all('a')
         ret = [str(a['href']) for a in ret]
+        logging.debug('Unfiltered episodes : {}'.format(ret))
+        filter_list = ['opening', 'ending', 'special', 'recap']
+        ret = list(filter(
+            lambda x: not any(s in x.lower() for s in filter_list), ret
+        ))
+        logging.debug('Filtered episodes : {}'.format(ret))
 
         if ret == []:
             err = 'No episodes found in url "{}"'.format(self.url)

--- a/anime_downloader/watch.py
+++ b/anime_downloader/watch.py
@@ -64,7 +64,8 @@ class Watcher:
             return anime
 
     def update_anime(self, anime):
-        if anime.meta['Status'].lower() == 'airing':
+        if not hasattr(anime, 'meta') or not anime.meta.get('Status') or \
+                anime.meta['Status'].lower() == 'airing':
             logging.info('Updating anime {}'.format(anime.title))
             AnimeInfo = self._get_anime_info_class(anime.url)
             newanime = AnimeInfo(anime.url, episodes_done=anime.episodes_done,


### PR DESCRIPTION
Kissanime has recaps, specials, opening, ending, etc. For now, let's just filter them out.

Also `Watcher.update` would error in master because `Kissanime` has no `meta`. This fixes that too.