### PR TITLE
Feature Request/Issue: Allowing users to set length of title to display

### DIFF
--- a/anime_downloader/cli.py
+++ b/anime_downloader/cli.py
@@ -179,13 +179,17 @@ def dl(ctx, anime_url, episode_range, url, player, skip_download, quality,
     help='The anime provider (website) for search.',
     type=click.Choice(['9anime', 'kissanime', 'twist.moe', 'kisscartoon'])
 )
+@click.option(
+    '--title', '-t', type=int, default=40,
+    help='Set the length of the title to display'
+)
 
 @click.option(
     '--log-level', '-ll', 'log_level',
     type=click.Choice(['DEBUG', 'INFO', 'WARNING', 'ERROR']),
     help='Sets the level of logger', default='INFO')
 def watch(anime_name, new, update_all, _list, quality, log_level, remove,
-          download_dir, provider):
+          download_dir, provider, title):
     """
     With watch you can keep track of any anime you watch.
 
@@ -208,7 +212,7 @@ def watch(anime_name, new, update_all, _list, quality, log_level, remove,
         else:
             query = click.prompt('Enter a anime name or url', type=str)
 
-        url = util.search(query, provider)
+        url = util.search(query, provider, title)
 
         watcher.new(url)
         sys.exit(0)

--- a/anime_downloader/util.py
+++ b/anime_downloader/util.py
@@ -30,22 +30,21 @@ def setup_logger(log_level):
     logger.setLevel(logging.WARNING)
 
 
-def format_search_results(search_results):
+def format_search_results(search_results, title_length):
     _, height = shutil.get_terminal_size()
     height -= 4  # Accounting for prompt
-
     ret = ''
     for idx, result in enumerate(search_results[:height]):
         try:
             meta = ' | '.join(val for _, val in result.meta.items())
         except AttributeError:
             meta = ''
-        ret += '{:2}: {:40.40}\t{:20.20}\n'.format(idx+1, result.title, meta)
+        ret += '{:2}: {}\t{:20.20}\n'.format(idx+1, result.title[:title_length+1], meta)
 
     return ret
 
 
-def search(query, provider):
+def search(query, provider, title_length=40):
     # Since this function outputs to stdout this should ideally be in
     # cli. But it is used in watch too. :(
     cls = get_anime_class(provider)
@@ -54,7 +53,7 @@ def search(query, provider):
     except Exception as e:
         logging.error(click.style(str(e), fg='red'))
         sys.exit(1)
-    click.echo(format_search_results(search_results))
+    click.echo(format_search_results(search_results, title_length))
 
     if not search_results:
         logging.error('No such Anime found. Please ensure correct spelling.')


### PR DESCRIPTION
## Description
An issue was brought up in #75 where the titles were cutoff as they were preset to 40 characters. This PR adds a flag `--title, -t <number|default=40>` which takes an integer and returns the title length provided by the user.

_Before Changes_
`anime watch 'my hero' --new --provider 'kissanime'`

Would result in
```
 1: Hitorijime My Hero	                    
 2: My Hero Academia (Dub)	                    
 3: My Hero Academia (Sub)	                    
 4: My Hero Academia 2 (Dub)	                    
 5: My Hero Academia 2 (Sub)	                    
 6: My Hero Academia 2 Episode 0 (Dub)	                    
 7: My Hero Academia 2 Episode 0 (Sub)	                    
 8: My Hero Academia 3 (Dub)	                    
 9: My Hero Academia 3 (Sub)	                    
10: My Hero Academia the Movie: The Two Heroe	                    
11: My Hero Academia the Movie: The Two Heroe	                    
12: My Hero Academia: Jump Festa 2016 Special	                    
13: My Hero Academia: Training of the Dead
```

_After Changes_
`anime watch 'my hero' --new --provider 'kissanime' --title 100`

```
 1: Hitorijime My Hero	                    
 2: My Hero Academia (Dub)	                    
 3: My Hero Academia (Sub)	                    
 4: My Hero Academia 2 (Dub)	                    
 5: My Hero Academia 2 (Sub)	                    
 6: My Hero Academia 2 Episode 0 (Dub)	                    
 7: My Hero Academia 2 Episode 0 (Sub)	                    
 8: My Hero Academia 3 (Dub)	                    
 9: My Hero Academia 3 (Sub)	                    
10: My Hero Academia the Movie: The Two Heroes (Dub)	      <---- full name displayed
11: My Hero Academia the Movie: The Two Heroes (Sub)	      <---- full name displayed           
12: My Hero Academia: Jump Festa 2016 Special	                    
13: My Hero Academia: Training of the Dead
```