### PR TITLE
Expand environment variables in the download_dir field of config.json

### DIFF
--- a/anime_downloader/config.py
+++ b/anime_downloader/config.py
@@ -67,6 +67,10 @@ class _Config:
             for key in DEFAULT_CONFIG.keys():
                 update(key, self._CONFIG, DEFAULT_CONFIG)
             self.write()
+            # Expand environment variables in download_dir (#222)
+            download_dir = self._CONFIG['dl']['download_dir']
+            download_dir = os.path.expandvars(download_dir)
+            self._CONFIG['dl']['download_dir'] = download_dir
 
     @property
     def CONTEXT_SETTINGS(self):


### PR DESCRIPTION
The main reason for this change is to be able to set the default download directory to something like `"$HOME/videos/anime"`. As far as I can tell, the initialization of `_Config` seems to be the only place where config.json is written to and `download_dir` is the only field which would really benefit from this. Writing to the file after expanding the environment variables would defeat the purpose, since they would just end up hard-coded again. If it became necessary to write to the config file from other parts of the code or to add expansion to more of the fields, it might make sense to change the dictionary into a class holding the raw strings with properties which would return the expanded values when they were accessed.