### PR TITLE
added 1080p support for gogo

### DIFF
--- a/anime_downloader/sites/gogoanime.py
+++ b/anime_downloader/sites/gogoanime.py
@@ -29,7 +29,7 @@ class GogoanimeEpisode(AnimeEpisode, sitename='gogoanime'):
 
 class GogoAnime(Anime, sitename='gogoanime'):
     sitename = 'gogoanime'
-    QUALITIES = ['360p', '480p', '720p']
+    QUALITIES = ['360p', '480p', '720p', '1080p']
     _episode_list_url = 'https://www2.gogoanime.se//load-list-episode'
     _search_api_url = 'https://ajax.apimovie.xyz/site/loadAjaxSearch'
 


### PR DESCRIPTION
Only works for hosts already supported (rapid and mp4upload).  For broader 1080p coverage, support for hosts openload and/or vidstreaming should be added.