### PR TITLE
Disable Streamango and Rapidvideo

### DIFF
--- a/anime_downloader/sites/animeflv.py
+++ b/anime_downloader/sites/animeflv.py
@@ -20,8 +20,7 @@ class Animeflv(Anime, sitename='animeflv'):
     version: subbed or latin
         subbed for subbed
         latin for Spanish
-    server: one of below
-        natsuki, streamango
+    server: natsuki
 
     """
     sitename = 'animeflv'
@@ -70,7 +69,6 @@ class AnimeflvEpisode(AnimeEpisode, sitename='animeflv'):
     # Hint:  https://github.com/Cartmanishere/zippyshare-scraper
 
     SERVERS = [
-        'streamango',
         'natsuki'
     ]
 
@@ -83,6 +81,8 @@ class AnimeflvEpisode(AnimeEpisode, sitename='animeflv'):
 
         server = self.config['server']
 
+        '''
+        Ignore preferred server for now. 
         # Trying preferred server from config first
         for video in videos:
             if video['server'] == server:
@@ -94,10 +94,8 @@ class AnimeflvEpisode(AnimeEpisode, sitename='animeflv'):
 
         logger.debug('Preferred server %s not found.  Trying all supported servers.', server)
 
-        # Trying streamango and natsuki.  The second for loop is not ideal.
+        '''
         for video in videos:
-            if video['server'] == 'streamango':
-                return [('streamango', video['code'])]
             if video['server'] == 'natsuki':
                 url = helpers.get(video['code'].replace('embed', 'check')).json()['file']
                 return [('no_extractor', url)]

--- a/anime_downloader/sites/animepahe.py
+++ b/anime_downloader/sites/animepahe.py
@@ -31,7 +31,7 @@ class AnimePaheEpisode(AnimeEpisode, sitename='animepahe'):
 
     def _get_sources(self):
 
-        supported_servers = ['kwik','mp4upload','rapidvideo']
+        supported_servers = ['kwik','mp4upload']
         episode_id = self.url.rsplit('/', 1)[-1]
 
         sourcetext = helpers.get(self.url, cf=True).text

--- a/anime_downloader/sites/gogoanime.py
+++ b/anime_downloader/sites/gogoanime.py
@@ -3,6 +3,7 @@ import re
 
 from anime_downloader.sites.anime import Anime, AnimeEpisode, SearchResult
 from anime_downloader.sites import helpers
+from anime_downloader.sites.exceptions import AnimeDLError, NotFoundError
 
 logger = logging.getLogger(__name__)
 
@@ -44,14 +45,15 @@ class GogoanimeEpisode(AnimeEpisode, sitename='gogoanime'):
                 extractor_class = element.get('class')[0]
                 source_url = element.a.get('data-video')
                 logger.debug('%s: %s' % (extractor_class, source_url))
-                # prefer streamango, else use mp4upload and rapidvideo as sources
+                # use mp4upload as source
 
-                if extractor_class == 'streamango':
-                    extractor_class = 'streamango'
-                elif extractor_class == 'mp4':
+                if extractor_class == 'mp4':
                     extractor_class = 'mp4upload'
-                elif extractor_class != 'rapidvideo':
-                    continue
+                else:
+                    raise AnimeDLError(
+                        'No supported download servers found.  Try a different provider. '
+                        'Check the issues here https://github.com/vn-ki/anime-downloader/issues. '
+                    )
                 logger.debug('%s: %s' % (extractor_class, source_url))
                 extractors_url.append((extractor_class, source_url,))
             return extractors_url

--- a/anime_downloader/sites/gogoanime.py
+++ b/anime_downloader/sites/gogoanime.py
@@ -29,12 +29,27 @@ class GogoanimeEpisode(AnimeEpisode, sitename='gogoanime'):
             soup_cdnfile = helpers.soupify(helpers.get(dl_page_url))
             cdnfile_url = []
 
-            for element in soup_cdnfile.find_all('a', href=re.compile('https://.*\.cdnfile\.info.*' + self.quality)):
-                extractor_class = 'no_extractor'
-                source_url = element.get('href')
-                logger.debug('%s: %s' % (extractor_class, source_url))
-                cdnfile_url.append((extractor_class, source_url,))
-            return cdnfile_url
+            if soup_cdnfile.find_all('a', href=re.compile('https://.*\.cdnfile\.info.*' + self.quality)):
+                for element in soup_cdnfile.find_all('a', href=re.compile('https://.*\.cdnfile\.info.*' + self.quality)):
+                    extractor_class = 'no_extractor'
+                    source_url = element.get('href')
+                    logger.debug('%s: %s' % (extractor_class, source_url))
+                    cdnfile_url.append((extractor_class, source_url,))
+                return cdnfile_url
+
+            elif soup_cdnfile.find_all('a', href=re.compile('https://.*\.cdnfile\.info.*' + 'orginalP.*')):
+                for element in soup_cdnfile.find_all('a', href=re.compile('https://.*\.cdnfile\.info.*' + 'orginalP.*')):
+                    extractor_class = 'no_extractor'
+                    source_url = element.get('href')
+                    logger.debug('%s: %s' % (extractor_class, source_url))
+                    cdnfile_url.append((extractor_class, source_url,))
+                return cdnfile_url
+
+            else:
+                raise AnimeDLError(
+                    'No supported download servers found.  Try a different provider. '
+                    'Check the issues here https://github.com/vn-ki/anime-downloader/issues. '
+                )
 
         else:
             soup = helpers.soupify(helpers.get(self.url))

--- a/anime_downloader/sites/gogoanime.py
+++ b/anime_downloader/sites/gogoanime.py
@@ -17,7 +17,6 @@ class GogoanimeEpisode(AnimeEpisode, sitename='gogoanime'):
         soup = helpers.soupify(helpers.get(self.url))
         dl_page_url = []
 
-
         server = self.config.get('server', 'cdn')
 
         if server == 'cdn':
@@ -30,7 +29,7 @@ class GogoanimeEpisode(AnimeEpisode, sitename='gogoanime'):
             soup_cdnfile = helpers.soupify(helpers.get(dl_page_url))
             cdnfile_url = []
 
-            for element in soup_cdnfile.find_all('a', href=re.compile('https://.*\.cdnfile\.info')):
+            for element in soup_cdnfile.find_all('a', href=re.compile('https://.*\.cdnfile\.info.*' + self.quality)):
                 extractor_class = 'no_extractor'
                 source_url = element.get('href')
                 logger.debug('%s: %s' % (extractor_class, source_url))

--- a/anime_downloader/sites/kissanime.py
+++ b/anime_downloader/sites/kissanime.py
@@ -20,8 +20,8 @@ class KissanimeEpisode(AnimeEpisode, sitename='kissanime'):
 
     def _scrape_episode(self, response):
         raise AnimeDLError(
-            'Kissanime is not currently working properly. Check the issues'
-            'here https://github.com/vn-ki/anime-downloader/issues. '
+            'Kissanime is not currently working properly.  Try a different provider. '
+            'Check the issues here https://github.com/vn-ki/anime-downloader/issues. '
         )
 
         rapid_re = re.compile(r'iframe.*src="https://(.*?)"')

--- a/anime_downloader/sites/kissanime.py
+++ b/anime_downloader/sites/kissanime.py
@@ -3,7 +3,7 @@ import logging
 
 from anime_downloader.sites.anime import AnimeEpisode, SearchResult, Anime
 from anime_downloader.sites import helpers
-from anime_downloader.sites.exceptions import NotFoundError
+from anime_downloader.sites.exceptions import AnimeDLError, NotFoundError
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +19,11 @@ class KissanimeEpisode(AnimeEpisode, sitename='kissanime'):
         return data
 
     def _scrape_episode(self, response):
+        raise AnimeDLError(
+            'Kissanime is not currently working properly. Check the issues'
+            'here https://github.com/vn-ki/anime-downloader/issues. '
+        )
+
         rapid_re = re.compile(r'iframe.*src="https://(.*?)"')
         rapid_url = rapid_re.findall(response.text)[0]
         return [('rapidvideo', rapid_url)]

--- a/anime_downloader/sites/nineanime.py
+++ b/anime_downloader/sites/nineanime.py
@@ -19,8 +19,8 @@ class NineAnimeEpisode(AnimeEpisode, sitename='9anime'):
 
     def _get_sources(self):
         servers = {
-            'rapidvideo': '33',
-            'streamango': '12',
+            #'rapidvideo': '33',
+            #'streamango': '12',
             'mp4upload': '35',
         }
         server = self.config.get('server', 'mp4upload')


### PR DESCRIPTION
Went through and disabled the code for streamango and rapidvideo.  Both sites are dead.  Also disabled Kissanime, as the captcha has broken the site for dl.

See issues: #254 and #263 

I also fixed gogoanime so it handles quality choice (and fallback qualities) for the default host (cdn).