### PR TITLE
Reorder of supported sites in readme and animepahe as default provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,17 +44,15 @@ Yeah. Me too! That's why this tool exists.
   
 ## Supported Sites
 
-- 9anime
-- twist.moe
-- KissAnime
-- KissCartoon
-- Gogoanime
-- AnimePahe
+- Animepahe
 - Anistream
-- Animeflv (Latin)
-- itsaturday.com
-- Animefreak
 - Animeflix
+- Animefreak
+- Gogoanime
+- itsaturday
+- Animeflv
+- Kissanime - requires Node.js
+- Kisscartoon - requires Node.js
 
 ## Installation
 

--- a/anime_downloader/config.py
+++ b/anime_downloader/config.py
@@ -12,17 +12,18 @@ DEFAULT_CONFIG = {
         'player': None,
         'skip_download': False,
         'download_dir': '.',
-        'quality': '720p',
+        'quality': '1080p',
         'fallback_qualities': ['720p', '480p', '360p'],
         'force_download': False,
         'file_format': '{anime_title}/{anime_title}_{ep_no}',
-        'provider': 'twist.moe',
+        'provider': 'animepahe',
         'external_downloader': '',
     },
     'watch': {
-        'quality': '720p',
+        'quality': '1080p',
+        'fallback_qualities': ['720p', '480p', '360p'],
         'log_level': 'INFO',
-        'provider': '9anime',
+        'provider': 'animepahe',
     },
     "siteconfig": {
         "nineanime": {

--- a/docs/usage/config.rst
+++ b/docs/usage/config.rst
@@ -28,8 +28,8 @@ The default config file is given below.
             "file_format": "{anime_title}/{anime_title}_{ep_no}",
             "force_download": false,
             "player": null,
-            "provider": "9anime",
-            "quality": "720p",
+            "provider": "animepahe",
+            "quality": "1080p",
             "skip_download": false,
             "url": false
         },
@@ -47,8 +47,8 @@ The default config file is given below.
         },
         "watch": {
             "log_level": "INFO",
-            "provider": "9anime",
-            "quality": "720p"
+            "provider": "animepahe",
+            "quality": "1080p"
         }
     }
 

--- a/docs/usage/dl.rst
+++ b/docs/usage/dl.rst
@@ -20,7 +20,7 @@ To search on kissanime,
 
 .. code:: bash
 
-   anime dl 'code geass' --provider kissanime
+   anime dl 'code geass' --provider animepahe
 
 Run ``anime dl --help`` for help text on ``dl`` subcommand.
 
@@ -31,29 +31,29 @@ Download directly
 
 ::
 
-   anime dl 'https://www7.9anime.is/watch/fullmetal-alchemist-brotherhood.0r7/j69y93'
+   anime dl 'https://animepahe.com/anime/fullmetal-alchemist-brotherhood'
 
 -  To download Fullmetal Alchemist: Brotherhood episode 1
 
 ::
 
-   anime dl 'https://www7.9anime.is/watch/fullmetal-alchemist-brotherhood.0r7/j69y93' --episodes 1
+   anime dl 'https://animepahe.com/anime/fullmetal-alchemist-brotherhood' --episodes 1
 
 -  To download Fullmetal Alchemist: Brotherhood episode 1 to 20
 
 ::
 
-   anime dl 'https://www7.9anime.is/watch/fullmetal-alchemist-brotherhood.0r7/j69y93' --episodes 1:21
+   anime dl 'https://animepahe.com/anime/fullmetal-alchemist-brotherhood' --episodes 1:21
 
 -  To get stream url of Fullmetal Alchemist: Brotherhood episode 1.
 
 ::
 
-   anime dl 'https://www7.9anime.is/watch/fullmetal-alchemist-brotherhood.0r7/j69y93' --url --episodes 1
+   anime dl 'https://animepahe.com/anime/fullmetal-alchemist-brotherhood' --url --episodes 1
 
 -  To play using vlc. (On windows use path to exe)
 
 ::
 
-   anime dl 'https://www7.9anime.is/watch/fullmetal-alchemist-brotherhood.0r7/j69y93' --play vlc --episodes 1
+   anime dl 'https://animepahe.com/anime/fullmetal-alchemist-brotherhood' --play vlc --episodes 1
 


### PR DESCRIPTION
I have made a rather lengthy comment in issue https://github.com/vn-ki/anime-downloader/issues/272. Then I decided that, perhaps, it would be a lot better if the provider list would be ordered from `it works all the time` to `why is it even on the list`. Thus `animepahe` has been put front and center both in the readme (apologies for the commit name on that one), but also in the docs where 9anime was still used, and of course, in the default configuration (I hope?).

This small effort is to make sure the `anime downloader` script actually seems to work in the eye of a new user, that perhaps, would think is it broken when it doesn't work with some other provider.