### PR TITLE
Fixed animeflix

### DIFF
--- a/anime_downloader/sites/animeflix.py
+++ b/anime_downloader/sites/animeflix.py
@@ -5,12 +5,11 @@ from anime_downloader.sites import helpers
 class AnimeFlix(Anime, sitename='animeflix'):
         """
         Site :https://animeflix.io/
-
         """
         sitename = 'animeflix'
-        search_url = 'https://www.animeflix.io/api/search'
-        anime_url = 'https://www.animeflix.io/shows'
-        episodeList_url = 'https://www.animeflix.io/api/anime-schema'
+        search_url = 'https://animeflix.io/api/search'
+        anime_url = 'https://animeflix.io/shows'
+        episodeList_url = 'https://animeflix.io/api/anime-schema'
         meta_url = 'https://animeflix.io/api/anime/detail'
         QUALITIES = ['360p', '480p', '720p', '1080p']
 

--- a/anime_downloader/sites/init.py
+++ b/anime_downloader/sites/init.py
@@ -6,7 +6,7 @@ ALL_ANIME_SITES = [
     ('gogoanime', 'gogoanime', 'GogoAnime'),
     ('kissanime', 'kissanime', 'KissAnime'), #Cloudflare confirmation
     ('kisscartoon', 'kisscartoon', 'KissCartoon'), #Cloudflare confirmation
-    ('twistmoe', 'twist.moe', 'TwistMoe'), #Need rework to bypass the javascript
+    ('twistmoe', 'twist.moe', 'TwistMoe'), #Needs rework to bypass the javascript
     ('animepahe', 'animepahe', 'AnimePahe'),
     ('animeflv', 'animeflv', 'Animeflv'), #Cloudflare confirmation
     ('itsaturday', 'itsaturday', 'Itsaturday'),

--- a/anime_downloader/sites/init.py
+++ b/anime_downloader/sites/init.py
@@ -5,13 +5,13 @@ ALL_ANIME_SITES = [
     ('nineanime', '9anime', 'NineAnime'),
     ('gogoanime', 'gogoanime', 'GogoAnime'),
     ('kissanime', 'kissanime', 'KissAnime'),
-    ('kisscartoon', 'kisscartoon', 'KissCartoon'), 
-    ('twistmoe', 'twist.moe', 'TwistMoe'), 
+    ('kisscartoon', 'kisscartoon', 'KissCartoon'),
+    ('twistmoe', 'twist.moe', 'TwistMoe'),
     ('animepahe', 'animepahe', 'AnimePahe'),
-    ('animeflv', 'animeflv', 'Animeflv'), 
+    ('animeflv', 'animeflv', 'Animeflv'),
     ('itsaturday', 'itsaturday', 'Itsaturday'),
     ('animefreak', 'animefreak', 'AnimeFreak'),
-    ('animeflix', 'animeflix', 'AnimeFlix'), 
+    ('animeflix', 'animeflix', 'AnimeFlix'),
 ]
 
 

--- a/anime_downloader/sites/init.py
+++ b/anime_downloader/sites/init.py
@@ -4,11 +4,11 @@ ALL_ANIME_SITES = [
     # ('filename', 'sitename', 'classname')
     ('nineanime', '9anime', 'NineAnime'),
     ('gogoanime', 'gogoanime', 'GogoAnime'),
-    ('kissanime', 'kissanime', 'KissAnime'), #Cloudflare confirmation
-    ('kisscartoon', 'kisscartoon', 'KissCartoon'), #Cloudflare confirmation
-    ('twistmoe', 'twist.moe', 'TwistMoe'), #Needs rework to bypass the javascript
+    ('kissanime', 'kissanime', 'KissAnime'),
+    ('kisscartoon', 'kisscartoon', 'KissCartoon'), 
+    ('twistmoe', 'twist.moe', 'TwistMoe'), 
     ('animepahe', 'animepahe', 'AnimePahe'),
-    ('animeflv', 'animeflv', 'Animeflv'), #Cloudflare confirmation
+    ('animeflv', 'animeflv', 'Animeflv'), 
     ('itsaturday', 'itsaturday', 'Itsaturday'),
     ('animefreak', 'animefreak', 'AnimeFreak'),
     ('animeflix', 'animeflix', 'AnimeFlix'), 

--- a/anime_downloader/sites/init.py
+++ b/anime_downloader/sites/init.py
@@ -4,15 +4,14 @@ ALL_ANIME_SITES = [
     # ('filename', 'sitename', 'classname')
     ('nineanime', '9anime', 'NineAnime'),
     ('gogoanime', 'gogoanime', 'GogoAnime'),
-    ('kissanime', 'kissanime', 'KissAnime'),
-    ('kisscartoon', 'kisscartoon', 'KissCartoon'),
-    ('twistmoe', 'twist.moe', 'TwistMoe'),
+    ('kissanime', 'kissanime', 'KissAnime'), #Cloudflare confirmation
+    ('kisscartoon', 'kisscartoon', 'KissCartoon'), #Cloudflare confirmation
+    ('twistmoe', 'twist.moe', 'TwistMoe'), #Need rework to bypass the javascript
     ('animepahe', 'animepahe', 'AnimePahe'),
-    ('anistream', 'anistream', 'Anistream'),
-    ('animeflv', 'animeflv', 'Animeflv'),
+    ('animeflv', 'animeflv', 'Animeflv'), #Cloudflare confirmation
     ('itsaturday', 'itsaturday', 'Itsaturday'),
     ('animefreak', 'animefreak', 'AnimeFreak'),
-    ('animeflix', 'animeflix', 'AnimeFlix'),
+    ('animeflix', 'animeflix', 'AnimeFlix'), 
 ]
 
 


### PR DESCRIPTION
www. in the url caused animeflix to fail with the error:
`requests.exceptions.ConnectionError: HTTPSConnectionPool(host='www.animeflix.io', port=443): Max retries exceeded with url: /api/search?q=code+geass (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x7f987c229850>: Failed to establish a new connection: [Errno -2] Name or service not known'))`

-Fixed animeflix by removing www 
-Removed anistream as that site shut down (https://anistream.xyz/)
-Added some comments

The sites with cloudflare confirmation are probably impossible to fetch links from