### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/anime_downloader/sites/twistmoe.py
+++ b/anime_downloader/sites/twistmoe.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 # Don't warn if not using fuzzywuzzy[speedup]
 with warnings.catch_warnings():
     warnings.simplefilter('ignore')
-    from fuzzywuzzy import process
+    from rapidfuzz import process
 
 BLOCK_SIZE = 16
 KEY = b"LXgIVP&PorO68Rq7dTx8N^lP!Fa5sGJ^*XK"

--- a/anime_downloader/watch.py
+++ b/anime_downloader/watch.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 # Don't warn if not using fuzzywuzzy[speedup]
 with warnings.catch_warnings():
     warnings.simplefilter('ignore')
-    from fuzzywuzzy import process
+    from rapidfuzz import process
 
 
 class Watcher:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'beautifulsoup4>=4.6.0',
         'requests>=2.18.4',
         'Click>=6.7',
-        'fuzzywuzzy>=0.17.0',
+        'rapidfuzz>=0.2.1',
         'coloredlogs>=10.0',
         'cfscrape>=2.0.5',
         'requests-cache>=0.4.13',


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy. (actually even faster since python-Levenshtein was not used)
