### PR TITLE
removed a2zanime

### DIFF
--- a/anime_downloader/sites/init.py
+++ b/anime_downloader/sites/init.py
@@ -13,7 +13,6 @@ ALL_ANIME_SITES = [
     ('animefreak', 'animefreak', 'AnimeFreak'),
     ('animeflix', 'animeflix', 'AnimeFlix'),
     ('dubbedanime', 'dubbedanime', 'Dubbedanime'),
-    ('a2zanime', 'a2zanime', 'A2zanime'),
     ('animeout', 'animeout', 'AnimeOut'),
     ('animerush','animerush','AnimeRush'),
     ('animesimple', 'animesimple', 'AnimeSimple'),


### PR DESCRIPTION
removed a2zanime from init as it got taken down and now redirects to https://asksuggestion.com/what-are-the-best-anime-websites-to-watch-anime-for-free/