### PR TITLE
Scrape AnimeFillerList and skip filler episodes

### DIFF
--- a/anime_downloader/commands/dl.py
+++ b/anime_downloader/commands/dl.py
@@ -72,10 +72,11 @@ sitenames = [v[1] for v in ALL_ANIME_SITES]
     '--choice', '-c',type=int,
     help='Choice to start downloading given anime number '
 )
+@click.option("--skip-fillers", is_flag=True, help="Skip downloading of fillers.")
 @click.pass_context
 def command(ctx, anime_url, episode_range, url, player, skip_download, quality,
             force_download, download_dir, file_format, provider,
-            external_downloader, chunk_size, disable_ssl, fallback_qualities, choice):
+            external_downloader, chunk_size, disable_ssl, fallback_qualities, choice, skip_fillers):
     """ Download the anime using the url or search for it.
     """
     util.print_info(__version__)
@@ -105,7 +106,15 @@ def command(ctx, anime_url, episode_range, url, player, skip_download, quality,
     if download_dir and not skip_download:
         logger.info('Downloading to {}'.format(os.path.abspath(download_dir)))
 
+    if skip_fillers:
+        fillers = util.get_filler_episodes()
+
     for episode in animes:
+        if skip_fillers and fillers:
+            if str(episode.ep_no) in fillers:
+                logger.info("Skipping episode {} because it is a filler.".format(episode.ep_no))
+                continue
+        
         if url:
             util.print_episodeurl(episode)
 

--- a/anime_downloader/util.py
+++ b/anime_downloader/util.py
@@ -14,7 +14,7 @@ import coloredlogs
 from tabulate import tabulate
 
 from anime_downloader import session
-from anime_downloader.sites import get_anime_class
+from anime_downloader.sites import get_anime_class, helpers
 from anime_downloader.const import desktop_headers
 
 logger = logging.getLogger(__name__)
@@ -256,6 +256,32 @@ def make_dir(path):
     except OSError as e:
         if e.errno != errno.EEXIST:
             raise
+
+
+def get_filler_episodes():
+    url = click.prompt("Input AnimeFillerList URL", type=str, err=True)
+
+    try:
+        logger.info("Fetching filler episodes...")
+
+        res = helpers.get(url)
+        soup = helpers.soupify(res.text)
+
+        episodes = []
+
+        for filler_episode in soup.find("div", attrs={"class": "filler"}).find_all("a"):
+            txt = filler_episode.text.strip()
+
+            for ep in txt.split("-"):
+                episodes.append(ep)
+
+        logger.debug("Found {} filler episodes.".format(len(episodes)))
+
+        return episodes
+    except:
+        logger.warn("Can't get filler episodes. Will download all specified episodes.")
+
+        return False
 
 
 class ClickListOption(click.Option):


### PR DESCRIPTION
Ability to be able to skip downloading of filler episodes given an [AnimeFillerList](https://www.animefillerlist.com/) url. 

Example for One Piece, ```https://www.animefillerlist.com/shows/one-piece```

Afaik, AFL has no API so you need to manually enter the url.