### PR TITLE
Moved hcaptcha and cookie stuff to utils

### DIFF
--- a/anime_downloader/extractors/kwik.py
+++ b/anime_downloader/extractors/kwik.py
@@ -1,19 +1,13 @@
 import logging
 import re
 import requests
-import os
-import pickle
-import tempfile
 
 from anime_downloader.extractors.base_extractor import BaseExtractor
 from anime_downloader.sites import helpers
 from anime_downloader import util
-from uuid import uuid4
-from time import time
-from secrets import choice
+from requests.exceptions import HTTPError
 
 logger = logging.getLogger(__name__)
-
 
 class Kwik(BaseExtractor):
     '''Extracts video url from kwik pages, Kwik has some `security`
@@ -21,76 +15,6 @@ class Kwik(BaseExtractor):
        and the kwik video stream when refered through the corresponding
        kwik video page.
     '''
-    headers = {
-            'User-Agent': choice((
-                'Mozilla/5.0 (Windows NT 6.2; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.90 Safari/537.36',
-                'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/605.1.15 (KHTML, like Gecko)',
-                'Mozilla/5.0 (iPad; CPU OS 9_3_5 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13G36',
-                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36'
-                ))
-            }
-    session = requests.session()
-    token = ''
-
-    #Captcha bypass stuff is mostly thanks to https://github.com/Futei/SineCaptcha
-    def _generate_mouse_movements(self, timestamp):
-        mouse_movements = []
-        last_movement = timestamp
-
-        for index in range(choice(range(1000, 10000))):
-            last_movement += choice(range(10))
-            mouse_movements.append([choice(range(500)), choice(range(500)), last_movement])
-
-        return mouse_movements
-
-    def bypass_captcha(self):
-        bypassed = False
-        
-        #Retry until success
-        while not bypassed:
-            site_key = str(uuid4())
-            response = self.session.post('https://hcaptcha.com/getcaptcha', data = {
-                'sitekey': site_key,
-                'host': 'kwik.cx'
-                }).json()
-            
-            key = response.get('key')
-            tasks = [row['task_key'] for row in response.get('tasklist')]
-            job = response.get('request_type')
-            timestamp = round(time()) + choice(range(30, 120))
-            answers = dict(zip(tasks, [choice(['true', 'false']) for index in range(len(tasks))]))
-
-            #Mouse movements
-            mm = self._generate_mouse_movements(timestamp)
-            ts = self._generate_mouse_movements(timestamp)
-            te = self._generate_mouse_movements(timestamp)
-            md = self._generate_mouse_movements(timestamp)
-            mu = self._generate_mouse_movements(timestamp)
-
-            json = {
-                'job_mode': job,
-                'answers': answers,
-                'serverdomain': 'kwik.cx',
-                'sitekey': site_key,
-                'motionData': {
-                    'st': timestamp,
-                    'dct': timestamp,
-                    'ts': ts,
-                    'te': te,
-                    'mm': mm,
-                    'md': md,
-                    'mu': mu
-                    },
-                'n': None,
-                'c': None
-                }
-
-            response = self.session.post(f'https://hcaptcha.com/checkcaptcha/{key}', json = json).json()
-            bypassed = response.get("pass")
-
-            if bypassed:
-                self.token = response.get("generated_pass_UUID")
-
 
     def _get_data(self):
         # Kwik servers don't have direct link access you need to be referred
@@ -101,30 +25,18 @@ class Kwik(BaseExtractor):
         self.url = self.url.replace(".cx/e/", ".cx/f/")
         self.headers.update({"referer": self.url})
 
-        TMP_DIR = tempfile.gettempdir()
+        cookies = util.get_hcaptcha_cookies(self.url)
 
-        if not os.path.isfile(TMP_DIR + '/kwik'):
-            logger.info("Bypassing captcha...")
-            self.bypass_captcha()
-
-            resp = helpers.soupify(self.session.get(self.url, headers = self.headers))
-            bypass_url = 'https://kwik.cx' + resp.form.get('action')
-
-            data = dict((x.get("name"), x.get("value")) for x in resp.select("form > input"))
-            data.update({"id": resp.strong.text, "g-recaptcha-response": self.token, "h-captcha-response": self.token})
-
-            resp = self.session.post(bypass_url, data = data, headers = self.headers)
-
-            if resp.status_code == 200:
-                logger.info("Captcha bypassed successfully!")
-                pickle.dump(resp.cookies, open(TMP_DIR + '/kwik', 'wb'))
+        if not cookies:
+            logger.info("No cookies")
+            resp = util.bypass_hcaptcha(self.url)
         else:
-            cookies = pickle.load(open(TMP_DIR + '/kwik', 'rb'))
-            resp = self.session.get(self.url, headers = self.headers, cookies = cookies)
+            resp = requests.get(self.url, cookies = cookies)
 
         title_re = re.compile(r'title>(.*)<')
 
         kwik_text = resp.text
+        cookies = resp.cookies
 
         title = title_re.search(kwik_text).group(1)
 
@@ -133,10 +45,11 @@ class Kwik(BaseExtractor):
         post_url = deobfuscated.form["action"]
         token = deobfuscated.input["value"]
 
-        resp = self.session.post(post_url, headers = self.headers, params={"_token": token}, allow_redirects = False)
+        resp = helpers.post(post_url, headers = self.headers, params={"_token": token}, cookies = cookies, allow_redirects = False)
         stream_url = resp.headers["Location"]
 
         logger.debug('Stream URL: %s' % stream_url)
+
         return {
             'stream_url': stream_url,
             'meta': {

--- a/anime_downloader/extractors/kwik.py
+++ b/anime_downloader/extractors/kwik.py
@@ -5,7 +5,6 @@ import requests
 from anime_downloader.extractors.base_extractor import BaseExtractor
 from anime_downloader.sites import helpers
 from anime_downloader import util
-from requests.exceptions import HTTPError
 
 logger = logging.getLogger(__name__)
 

--- a/anime_downloader/extractors/kwik.py
+++ b/anime_downloader/extractors/kwik.py
@@ -34,11 +34,18 @@ class Kwik(BaseExtractor):
         title_re = re.compile(r'title>(.*)<')
 
         kwik_text = resp.text
-        cookies = resp.cookies
 
-        title = title_re.search(kwik_text).group(1)
+        try:
+            deobfuscated = helpers.soupify(util.deobfuscate_packed_js(re.search(r'<(script).*(var\s+_.*escape.*?)</\1>(?s)', kwik_text).group(2)))
+        except AttributeError:
+            resp = util.bypass_hcaptcha(self.url)
+            kwik_text = resp.text
+            deobfuscated = helpers.soupify(util.deobfuscate_packed_js(re.search(r'<(script).*(var\s+_.*escape.*?)</\1>(?s)', kwik_text).group(2)))
+        finally:
+            cookies = resp.cookies
+            title = title_re.search(kwik_text).group(1)
 
-        deobfuscated = helpers.soupify(util.deobfuscate_packed_js(re.search(r'<(script).*(var\s+_.*escape.*?)</\1>(?s)', kwik_text).group(2)))
+
 
         post_url = deobfuscated.form["action"]
         token = deobfuscated.input["value"]

--- a/anime_downloader/extractors/kwik.py
+++ b/anime_downloader/extractors/kwik.py
@@ -27,7 +27,6 @@ class Kwik(BaseExtractor):
         cookies = util.get_hcaptcha_cookies(self.url)
 
         if not cookies:
-            logger.info("No cookies")
             resp = util.bypass_hcaptcha(self.url)
         else:
             resp = requests.get(self.url, cookies = cookies)

--- a/anime_downloader/util.py
+++ b/anime_downloader/util.py
@@ -318,7 +318,7 @@ def bypass_hcaptcha(url):
 def get_hcaptcha_cookies(url):
     """
     :param url: url that you want to use cookies for
-    :return: returns cookies if they were stored, or False, if they weren't
+    :return: returns cookies if they were stored, or nothing, if they weren't
     """
 
     COOKIE_FILE = f'{tempfile.gettempdir()}/{urlparse(url).netloc}'

--- a/anime_downloader/util.py
+++ b/anime_downloader/util.py
@@ -11,7 +11,14 @@ import time
 import ast
 import math
 import coloredlogs
+import pickle
+import tempfile
+import requests
 from tabulate import tabulate
+from uuid import uuid4
+from time import time
+from secrets import choice
+from urllib.parse import urlparse
 
 from anime_downloader import session
 from anime_downloader.sites import get_anime_class, helpers
@@ -225,6 +232,100 @@ def format_command(cmd, episode, file_format, path):
     cmd = [format_filename(c, episode) for c in cmd]
     return cmd
 
+
+def bypass_hcaptcha(url):
+    """
+    :param url: url to page which gives hcaptcha
+    :return: Returns Response object (cookies stored for future use)
+    """
+    host = urlparse(url).netloc
+    bypassed = False
+    session = requests.session()
+
+    headers = {
+        'User-Agent': choice((
+            'Mozilla/5.0 (Windows NT 6.2; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.90 Safari/537.36',
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/605.1.15 (KHTML, like Gecko)',
+            'Mozilla/5.0 (iPad; CPU OS 9_3_5 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13G36',
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36'
+            ))
+        }
+
+    logger.info("Bypassing captcha...")
+
+    #Retry until success
+    while not bypassed:
+        site_key = str(uuid4())
+        response = session.post('https://hcaptcha.com/getcaptcha', headers = headers, data = {
+            'sitekey': site_key,
+            'host': host
+            }).json()
+
+        try:
+            key = response['key']
+            tasks = [row['task_key'] for row in response['tasklist']]
+            job = response['request_type']
+            timestamp = round(time()) + choice(range(30, 120))
+            answers = dict(zip(tasks, [choice(['true', 'false']) for index in range(len(tasks))]))
+
+            mouse_movements = []
+            last_movement = timestamp
+
+            for index in range(choice(range(1000, 10000))):
+                last_movement += choice(range(10))
+                mouse_movements.append([choice(range(500)), choice(range(500)), last_movement])
+
+            json = {
+                'job_mode': job,
+                'answers': answers,
+                'serverdomain': host,
+                'sitekey': site_key,
+                'motionData': {
+                    'st': timestamp,
+                    'dct': timestamp,
+                    'mm': mouse_movements
+                    }
+                }
+
+            response = session.post(f'https://hcaptcha.com/checkcaptcha/{key}', json = json)
+
+            response = response.json()
+            bypassed = response['pass']
+        except (TypeError, KeyError) as e:
+            logger.info(e)
+
+        if bypassed:
+            token = response['generated_pass_UUID']
+
+            resp = helpers.soupify(session.get(url))
+            bypass_url = f'https://{host}{resp.form.get("action")}'
+
+            data = dict((x.get('name'), x.get('value')) for x in resp.select('form > input'))
+            data.update({'id': resp.strong.text, 'g-recaptcha-response': token, 'h-captcha-response': token})
+
+            resp = session.post(bypass_url, data = data)
+
+            if resp.status_code == 200:
+                pickle.dump(resp.cookies, open(f'{tempfile.gettempdir()}/{host}', 'wb'))
+                logger.info("Succesfully bypassed captcha!")
+                
+                return resp
+            else:
+                bypassed = False
+
+
+def get_hcaptcha_cookies(url):
+    """
+    :param url: url that you want to use cookies for
+    :return: returns cookies if they were stored, or False, if they weren't
+    """
+
+    COOKIE_FILE = f'{tempfile.gettempdir()}/{urlparse(url).netloc}'
+
+    if os.path.isfile(COOKIE_FILE):
+        return pickle.load(open(COOKIE_FILE, 'rb'))
+    else:
+        return False
 
 def deobfuscate_packed_js(packedjs):
     return eval_in_node('eval=console.log; ' + packedjs)

--- a/anime_downloader/util.py
+++ b/anime_downloader/util.py
@@ -292,7 +292,7 @@ def bypass_hcaptcha(url):
             response = response.json()
             bypassed = response['pass']
         except (TypeError, KeyError) as e:
-            logger.info(e)
+            pass
 
         if bypassed:
             token = response['generated_pass_UUID']

--- a/anime_downloader/util.py
+++ b/anime_downloader/util.py
@@ -233,7 +233,7 @@ def format_command(cmd, episode, file_format, path):
     return cmd
 
 
-#Credits to: https://github.com/Futei/SineCaptcha - you should check that out by the way, it's hilarious
+#Credits to: https://github.com/Futei/SineCaptcha
 def bypass_hcaptcha(url):
     """
     :param url: url to page which gives hcaptcha

--- a/anime_downloader/util.py
+++ b/anime_downloader/util.py
@@ -324,8 +324,6 @@ def get_hcaptcha_cookies(url):
 
     if os.path.isfile(COOKIE_FILE):
         return pickle.load(open(COOKIE_FILE, 'rb'))
-    else:
-        return False
 
 def deobfuscate_packed_js(packedjs):
     return eval_in_node('eval=console.log; ' + packedjs)

--- a/anime_downloader/util.py
+++ b/anime_downloader/util.py
@@ -233,6 +233,7 @@ def format_command(cmd, episode, file_format, path):
     return cmd
 
 
+#Credits to: https://github.com/Futei/SineCaptcha - you should check that out by the way, it's hilarious
 def bypass_hcaptcha(url):
     """
     :param url: url to page which gives hcaptcha

--- a/anime_downloader/util.py
+++ b/anime_downloader/util.py
@@ -292,7 +292,7 @@ def bypass_hcaptcha(url):
 
             response = response.json()
             bypassed = response['pass']
-        except (TypeError, KeyError) as e:
+        except (TypeError, KeyError):
             pass
 
         if bypassed:


### PR DESCRIPTION
This adds the hcaptcha bypass to util, along with a `get_hcaptcha_cookies` function. Currently, this is implemented in Kwik only - but works with other sites (tested with vidstreaming link provided by @ngomile, however haven't implemented it due to @Blatzar's comment on #399, which this supersedes).

This is also less error prone as it catches errors that occasionally occur (namely KeyError and TypeError - due to an unexpected or no response from the server on some failures). 