### PR TITLE
make pycryptodome optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
   fast_finish: true
 before_install:
   - pip install pytest-cov
+  - pip install pycryptodome 
 install:
   - pip install -e ".[dev]"
 script:

--- a/anime_downloader/sites/twistmoe.py
+++ b/anime_downloader/sites/twistmoe.py
@@ -4,12 +4,6 @@ import warnings
 import requests_cache
 import requests
 import logging
-
-try:
-    from Crypto.Cipher import AES
-
-except ImportError:
-    logger.warn("import Failed, check to make sure pycryptodome is installed")
     
 from anime_downloader.sites.anime import Anime, AnimeEpisode, SearchResult
 from anime_downloader.sites import helpers
@@ -17,6 +11,13 @@ from anime_downloader.util import eval_in_node
 
 
 logger = logging.getLogger(__name__)
+
+try:
+    from Crypto.Cipher import AES
+
+except ImportError:
+    logger.warn("import Failed, check to make sure pycryptodome is installed")
+
 # Don't warn if not using fuzzywuzzy[speedup]
 with warnings.catch_warnings():
     warnings.simplefilter('ignore')

--- a/anime_downloader/sites/twistmoe.py
+++ b/anime_downloader/sites/twistmoe.py
@@ -6,6 +6,9 @@ import requests_cache
 import requests
 import logging
 
+except importError:
+    logger.warn("import Failed, check to make sure pycryptodome is installed")
+    
 from anime_downloader.sites.anime import Anime, AnimeEpisode, SearchResult
 from anime_downloader.sites import helpers
 from anime_downloader.util import eval_in_node

--- a/anime_downloader/sites/twistmoe.py
+++ b/anime_downloader/sites/twistmoe.py
@@ -17,7 +17,7 @@ try:
 
 except ImportError:
     logger.warning("import Failed, check to make sure pycryptodome is installed")
-    logger.error(ImportError)
+    logger.error(str(ImportError))
 
 # Don't warn if not using fuzzywuzzy[speedup]
 with warnings.catch_warnings():

--- a/anime_downloader/sites/twistmoe.py
+++ b/anime_downloader/sites/twistmoe.py
@@ -16,7 +16,7 @@ try:
     from Crypto.Cipher import AES
 
 except ImportError:
-    logger.warn("import Failed, check to make sure pycryptodome is installed")
+    logger.warning("import Failed, check to make sure pycryptodome is installed")
 
 # Don't warn if not using fuzzywuzzy[speedup]
 with warnings.catch_warnings():

--- a/anime_downloader/sites/twistmoe.py
+++ b/anime_downloader/sites/twistmoe.py
@@ -1,10 +1,12 @@
-from Crypto.Cipher import AES
 import base64
 from hashlib import md5
 import warnings
 import requests_cache
 import requests
 import logging
+
+try:
+    from Crypto.Cipher import AES
 
 except importError:
     logger.warn("import Failed, check to make sure pycryptodome is installed")

--- a/anime_downloader/sites/twistmoe.py
+++ b/anime_downloader/sites/twistmoe.py
@@ -16,7 +16,7 @@ try:
     from Crypto.Cipher import AES
 
 except ImportError:
-    logger.warning("import Failed, check to make sure pycryptodome is installed")
+    logger.error("import Failed, check to make sure pycryptodome is installed")
 
 # Don't warn if not using fuzzywuzzy[speedup]
 with warnings.catch_warnings():

--- a/anime_downloader/sites/twistmoe.py
+++ b/anime_downloader/sites/twistmoe.py
@@ -8,7 +8,7 @@ import logging
 try:
     from Crypto.Cipher import AES
 
-except importError:
+except ImportError:
     logger.warn("import Failed, check to make sure pycryptodome is installed")
     
 from anime_downloader.sites.anime import Anime, AnimeEpisode, SearchResult

--- a/anime_downloader/sites/twistmoe.py
+++ b/anime_downloader/sites/twistmoe.py
@@ -16,7 +16,8 @@ try:
     from Crypto.Cipher import AES
 
 except ImportError:
-    logger.error("import Failed, check to make sure pycryptodome is installed")
+    logger.warning("import Failed, check to make sure pycryptodome is installed")
+    logger.error(ImportError)
 
 # Don't warn if not using fuzzywuzzy[speedup]
 with warnings.catch_warnings():

--- a/anime_downloader/sites/twistmoe.py
+++ b/anime_downloader/sites/twistmoe.py
@@ -16,7 +16,7 @@ try:
     from Crypto.Cipher import AES
 
 except ImportError:
-    logger.warning("import Failed, check to make sure pycryptodome is installed")
+    logger.warning("import Failed, check to make sure pycryptodome is installed \nRun this command to install the required module 'pip install pycryptodome'")
     raise ImportError
 
 # Don't warn if not using fuzzywuzzy[speedup]

--- a/anime_downloader/sites/twistmoe.py
+++ b/anime_downloader/sites/twistmoe.py
@@ -17,7 +17,7 @@ try:
 
 except ImportError:
     logger.warning("import Failed, check to make sure pycryptodome is installed")
-    logger.error(str(ImportError))
+    raise ImportError
 
 # Don't warn if not using fuzzywuzzy[speedup]
 with warnings.catch_warnings():

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
         'cfscrape>=2.0.5',
         'requests-cache>=0.4.13',
         'tabulate>=0.8.3',
-
     ],
     extras_require={
         'selescrape': ['selenium'],

--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,11 @@ setup(
         'cfscrape>=2.0.5',
         'requests-cache>=0.4.13',
         'tabulate>=0.8.3',
-        'pycryptodome>=3.8.2',
+
     ],
     extras_require={
         'selescrape': ['selenium'],
+        'pycryptodome>=3.8.2',
         'dev': [
             'pytest',
             'httpretty'

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     extras_require={
         'selescrape': ['selenium'],
-        'pycryptodome>=3.8.2',
+        'crypto' : ['pycryptodome>=3.8.2'],
         'dev': [
             'pytest',
             'httpretty'

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         'tabulate>=0.8.3',
     ],
     extras_require={
-        'selescrape': ['selenium'],
+        'selescrape' : ['selenium'],
         'crypto' : ['pycryptodome>=3.8.2'],
         'dev': [
             'pytest',


### PR DESCRIPTION
I can't install pycryptodome, and apparently only one provider uses it, so I propose to make it optional