### PR TITLE
made sort_sources less prone to errors

### DIFF
--- a/anime_downloader/sites/anime.py
+++ b/anime_downloader/sites/anime.py
@@ -383,7 +383,7 @@ class AnimeEpisode:
         logger.debug('Data : {}'.format(data))
 
         #Sorts the dicts by preferred server in config
-        sorted_by_server = sorted(data, key=lambda x: servers.index(x['server']))
+        sorted_by_server = sorted(data, key=lambda x: servers.index(x['server']) if x['server'] in servers else len(data))
 
         #Sorts the above by preferred language 
         #resulting in a list with the dicts sorted by language and server


### PR DESCRIPTION
Having unspecified server in config will lead to an error, this is bad if the provider gets updated or isn't tested enough. This will basically make any unspecified servers be placed last in list.

I rejected this idea in the making because I didn't think that providers could get updates.