### PR TITLE
aria2 default external downloader.

### DIFF
--- a/anime_downloader/config.py
+++ b/anime_downloader/config.py
@@ -18,7 +18,7 @@ DEFAULT_CONFIG = {
         'force_download': False,
         'file_format': '{anime_title}/{anime_title}_{ep_no}',
         'provider': 'twist.moe',
-        'external_downloader': '',
+        'external_downloader': '{aria2}',
         'aria2c_for_torrents': False,
         'selescrape_browser': None,
         'selescrape_browser_executable_path' : None,


### PR DESCRIPTION
When aria2 isn't installed it will prompt the user to install it, but when it's installed it won't use it since the previous config generated using no external downloader will be used. This results in a confusing install, especially with aria2 being in curly brackets.

TODO: check what happends in a clean install without aria2 when config uses aria2