### PR TITLE
Added a custom extractor that can be used if a provider wants to add the referer by itself.

### DIFF
--- a/anime_downloader/extractors/custom.py
+++ b/anime_downloader/extractors/custom.py
@@ -1,0 +1,9 @@
+from anime_downloader.extractors.base_extractor import BaseExtractor
+
+
+class Custom(BaseExtractor):
+    def _get_data(self):
+        return {
+            'stream_url': self.url.split('\n')[0],
+            'referer': self.url.split('\n')[1]
+        }

--- a/anime_downloader/extractors/init.py
+++ b/anime_downloader/extractors/init.py
@@ -14,6 +14,12 @@ ALL_EXTRACTORS = [
         'class': 'AnimeVideo',
     },
     {
+        'sitename': 'no_extractor',
+        'modulename': 'custom',
+        'regex': 'no_extractor',
+        'class': 'Custom',
+    },
+    {
         'sitename': 'animeonline360',
         'modulename': 'animeonline360',
         'regex': 'animeonline360',

--- a/anime_downloader/extractors/init.py
+++ b/anime_downloader/extractors/init.py
@@ -14,9 +14,9 @@ ALL_EXTRACTORS = [
         'class': 'AnimeVideo',
     },
     {
-        'sitename': 'no_extractor',
+        'sitename': 'custom',
         'modulename': 'custom',
-        'regex': 'no_extractor',
+        'regex': 'custom',
         'class': 'Custom',
     },
     {


### PR DESCRIPTION
It will split the url using a newline (\n), the 1st index will be the stream_url and the 2nd index will be the referer.