### PR TITLE
changed how the episodes list is handled for anime8

### DIFF
--- a/anime_downloader/config.py
+++ b/anime_downloader/config.py
@@ -59,7 +59,8 @@ DEFAULT_CONFIG = {
             'server': 'natsuki',
         },
         'anime8': {
-            'version':'subbed'
+            'version':'subbed',
+            'include_special_eps': False
         },
         'gogoanime': {
             'server': 'cdn',

--- a/anime_downloader/sites/anime8.py
+++ b/anime_downloader/sites/anime8.py
@@ -37,7 +37,6 @@ class Anime8(Anime, sitename = 'anime8'):
         special_eps = []
         special_seperator = ['-Preview', '-Special']
 
-
         for episode in eps:
             ep_text = episode.split('/')[-1].split('?')[0] #Getting the episode type from the url
 

--- a/anime_downloader/sites/anime8.py
+++ b/anime_downloader/sites/anime8.py
@@ -31,11 +31,15 @@ class Anime8(Anime, sitename = 'anime8'):
         soup = helpers.soupify(helpers.get(link).text)
         eps = soup.select('a[class*="btn-eps first-ep last-ep"]')
         eps = [x.get('href') for x in eps]
-        count = range(len(eps) - 1)
-        for a, b in zip(eps, count):
-            if '-Preview' in a:
-                eps.pop(b)
-        return eps
+        correct_eps = []
+        skip_eps = ['-Preview', '-Special', '-Sneak-Peak']
+        for episode in eps:
+            for skip in skip_eps:
+                if skip in episode:
+                    continue
+            else:
+                correct_eps.append(episode)
+        return correct_eps
 
 
     def _scrape_metadata(self):

--- a/anime_downloader/sites/anime8.py
+++ b/anime_downloader/sites/anime8.py
@@ -32,13 +32,16 @@ class Anime8(Anime, sitename = 'anime8'):
         eps = soup.select('a[class*="btn-eps first-ep last-ep"]')
         eps = [x.get('href') for x in eps]
         correct_eps = []
-        skip_eps = ['-Preview', '-Special', '-Sneak-Peak']
+        special_eps = []
+        skip_eps = ['-Preview', '-Special']
         for episode in eps:
-            for skip in skip_eps:
-                if skip in episode:
-                    continue
+            ep_text = episode.split('/')[-1].split('?')[0]
+            if ep_text in skip_eps or '-Sneak-Peak' in ep_text:
+                if not '-Sneak-Peak' in ep_text:
+                    special_eps.append(episode)
             else:
                 correct_eps.append(episode)
+        correct_eps.extend(special_eps)
         return correct_eps
 
 

--- a/anime_downloader/sites/anime8.py
+++ b/anime_downloader/sites/anime8.py
@@ -41,7 +41,7 @@ class Anime8(Anime, sitename = 'anime8'):
         for episode in eps:
             ep_text = episode.split('/')[-1].split('?')[0] #Getting the episode type from the url
 
-            #Only "The God of High School" has a sneak peak episode and it is broken in the 1st 10 eps
+            #Only "The God of High School" has a sneak peak episode and it is broken in the 1st 10 seconds
             if '-Sneak-Peak' in ep_text:
                 continue 
 

--- a/anime_downloader/sites/anime8.py
+++ b/anime_downloader/sites/anime8.py
@@ -31,17 +31,31 @@ class Anime8(Anime, sitename = 'anime8'):
         soup = helpers.soupify(helpers.get(link).text)
         eps = soup.select('a[class*="btn-eps first-ep last-ep"]')
         eps = [x.get('href') for x in eps]
+
+        #Seperating normal episodes from the special episodes
         correct_eps = []
         special_eps = []
-        skip_eps = ['-Preview', '-Special']
+        special_seperator = ['-Preview', '-Special']
+
+
         for episode in eps:
-            ep_text = episode.split('/')[-1].split('?')[0]
-            if ep_text in skip_eps or '-Sneak-Peak' in ep_text:
-                if not '-Sneak-Peak' in ep_text:
-                    special_eps.append(episode)
+            ep_text = episode.split('/')[-1].split('?')[0] #Getting the episode type from the url
+
+            #Only "The God of High School" has a sneak peak episode and it is broken in the 1st 10 eps
+            if '-Sneak-Peak' in ep_text:
+                continue 
+
+            # Here i add the special episodes to a seperate list
+            if ep_text in special_seperator:
+                special_eps.append(episode)
+
+            # Here i add the normal episodes to the correct_eps list
             else:
                 correct_eps.append(episode)
-        correct_eps.extend(special_eps)
+
+        # If configured to do so it will add all the special eps to the end of the list
+        if self.config['include_special_eps']:
+            correct_eps.extend(special_eps)
         return correct_eps
 
 


### PR DESCRIPTION
even if eps.pop() was not faulty, its not bad to remove it just in case, i added a list and a for loop for all the eps that we may want to skip.
suggestion: adding those special eps at the end of the list instead of removing them, because some anime are only made of special eps.