### PR TITLE
Remove gogoanime

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ Yeah. Me too! That's why this tool exists.
 - Darkanime
 - Dbanimes 
 - FastAni
-- Gogoanime
 - GurminderBoparai (AnimeChameleon)
 - HorribleSubs
 - itsaturday

--- a/anime_downloader/sites/init.py
+++ b/anime_downloader/sites/init.py
@@ -23,7 +23,6 @@ ALL_ANIME_SITES = [
     ('dbanimes', 'dbanimes', 'DBAnimes'),
     # ('erairaws', 'erai-raws', 'EraiRaws'),
     ('fastani', 'fastani', 'FastAni'),
-    ('gogoanime', 'gogoanime', 'GogoAnime'),
     ('horriblesubs', 'horriblesubs', 'HorribleSubs'),
     ('itsaturday', 'itsaturday', 'Itsaturday'),
     ('justdubs','justdubs','JustDubs'),


### PR DESCRIPTION
Gogoanime provides the same sources as vidstream, gogoanime works, but to ease maintenance I'm removing duplicate providers. 

