### PR TITLE
Change how config is read

### DIFF
--- a/anime_downloader/config.py
+++ b/anime_downloader/config.py
@@ -232,7 +232,7 @@ class _Config:
     def _read_config(self):
         with open(self.CONFIG_FILE, 'r') as configfile:
             try:
-                conf = json.load(configfile)
+                conf = eval(configfile.read().replace("true", "True").replace("false", "False").replace("null", "None"))
             except:
                 raise SyntaxWarning('The config file is not correctly formatted')
         return conf


### PR DESCRIPTION
This changes the method of reading from config.json from `json.load` to `eval`.

Why? Because `json.load` doesn't allow backslashes in config.json (unless they are themselves escaped) - which is a problem to windows users.

Tested on my config. Tested on config after deleting config. 

Could stand to be tested further by other people. 