### PR TITLE
Remove unnecessary download_episodes function

### DIFF
--- a/anime_downloader/util.py
+++ b/anime_downloader/util.py
@@ -207,6 +207,7 @@ def print_episodeurl(episode):
     # Currently I don't know of a way to specify referer in url itself so leaving it here.
     print(episode.source().stream_url)
 
+
 def play_episode(episode, *, player, title):
     if player == 'mpv':
         p = subprocess.Popen([
@@ -293,100 +294,6 @@ def format_command(cmd, episode, file_format, speed_limit, path):
     cmd = [c.format(**rep_dict) for c in cmd]
     cmd = [format_filename(c, episode) for c in cmd]
     return cmd
-
-
-# Credits to: https://github.com/Futei/SineCaptcha
-def bypass_hcaptcha(url):
-    """
-    :param url: url to page which gives hcaptcha
-    :return: Returns Response object (cookies stored for future use)
-    """
-    host = urlparse(url).netloc
-    bypassed = False
-    session = requests.session()
-
-    headers = {
-        'User-Agent': choice((
-            'Mozilla/5.0 (Windows NT 6.2; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.90 Safari/537.36',
-            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/605.1.15 (KHTML, like Gecko)',
-            'Mozilla/5.0 (iPad; CPU OS 9_3_5 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13G36',
-            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36'
-        ))
-    }
-
-    logger.info("Bypassing captcha...")
-
-    # Retry until success
-    while not bypassed:
-        site_key = str(uuid4())
-        response = session.post('https://hcaptcha.com/getcaptcha', headers=headers, data={
-            'sitekey': site_key,
-            'host': host
-        }).json()
-
-        try:
-            key = response['key']
-            tasks = [row['task_key'] for row in response['tasklist']]
-            job = response['request_type']
-            timestamp = round(time()) + choice(range(30, 120))
-            answers = dict(zip(tasks, [choice(['true', 'false']) for index in range(len(tasks))]))
-
-            mouse_movements = []
-            last_movement = timestamp
-
-            for index in range(choice(range(1000, 10000))):
-                last_movement += choice(range(10))
-                mouse_movements.append([choice(range(500)), choice(range(500)), last_movement])
-
-            json = {
-                'job_mode': job,
-                'answers': answers,
-                'serverdomain': host,
-                'sitekey': site_key,
-                'motionData': {
-                    'st': timestamp,
-                    'dct': timestamp,
-                    'mm': mouse_movements
-                }
-            }
-
-            response = session.post(f'https://hcaptcha.com/checkcaptcha/{key}', json=json)
-
-            response = response.json()
-            bypassed = response['pass']
-        except (TypeError, KeyError):
-            pass
-
-        if bypassed:
-            token = response['generated_pass_UUID']
-
-            resp = helpers.soupify(session.get(url))
-            bypass_url = f'https://{host}{resp.form.get("action")}'
-
-            data = dict((x.get('name'), x.get('value')) for x in resp.select('form > input'))
-            data.update({'id': resp.strong.text, 'g-recaptcha-response': token, 'h-captcha-response': token})
-
-            resp = session.post(bypass_url, data=data)
-
-            if resp.status_code == 200:
-                pickle.dump(resp.cookies, open(f'{tempfile.gettempdir()}/{host}', 'wb'))
-                logger.info("Succesfully bypassed captcha!")
-
-                return resp
-            else:
-                bypassed = False
-
-
-def get_hcaptcha_cookies(url):
-    """
-    :param url: url that you want to use cookies for
-    :return: returns cookies if they were stored, or nothing, if they weren't
-    """
-
-    COOKIE_FILE = f'{tempfile.gettempdir()}/{urlparse(url).netloc}'
-
-    if os.path.isfile(COOKIE_FILE):
-        return pickle.load(open(COOKIE_FILE, 'rb'))
 
 
 def deobfuscate_packed_js(packedjs):

--- a/anime_downloader/util.py
+++ b/anime_downloader/util.py
@@ -35,7 +35,6 @@ __all__ = [
     'parse_episode_range',
     'parse_ep_str',
     'print_episodeurl',
-    'download_episode',
     'play_episode',
     'print_info',
 ]
@@ -207,12 +206,6 @@ def print_episodeurl(episode):
     # else:
     # Currently I don't know of a way to specify referer in url itself so leaving it here.
     print(episode.source().stream_url)
-
-
-def download_episode(episode, **kwargs):
-    episode.download(**kwargs)
-    print()
-
 
 def play_episode(episode, *, player, title):
     if player == 'mpv':


### PR DESCRIPTION
Not really used anywhere: https://github.com/vn-ki/anime-downloader/search?q=download_episode&type=

Function can easily be replicated by doing `episode.download()`.

`dl`, `ezdl`, and `download` (using `watch`) have been tested to work with both aria2c and internal (barring `download` from `watch` which fails before the changes and after the changes as well when used with internal - works fine on aria2c) 