### PR TITLE
Unencode urls for printing

### DIFF
--- a/anime_downloader/util.py
+++ b/anime_downloader/util.py
@@ -18,7 +18,7 @@ import requests
 from tabulate import tabulate
 from uuid import uuid4
 from secrets import choice
-from urllib.parse import urlparse
+from urllib.parse import urlparse, unquote
 
 from anime_downloader import session
 from anime_downloader.sites import get_anime_class, helpers
@@ -207,7 +207,7 @@ def print_episodeurl(episode):
     #    print(episode.source().stream_url + "?referer=" +  episode.source().referer)
     # else:
     # Currently I don't know of a way to specify referer in url itself so leaving it here.
-    print(episode.source().stream_url)
+    print(unquote(episode.source().stream_url))
 
 
 def play_episode(episode, *, player, title):

--- a/anime_downloader/util.py
+++ b/anime_downloader/util.py
@@ -207,7 +207,8 @@ def print_episodeurl(episode):
     #    print(episode.source().stream_url + "?referer=" +  episode.source().referer)
     # else:
     # Currently I don't know of a way to specify referer in url itself so leaving it here.
-    print(unquote(episode.source().stream_url))
+    url = episode.url if episode.url.startswith("magnet") else episode.source().stream_url
+    print(unquote(url))
 
 
 def play_episode(episode, *, player, title):


### PR DESCRIPTION
This changes how URLs look when printed. They are more readable as encoded characters are unencoded, and there isn't a loss of functionality as such links can still be used in browsers. 

This would also make testing PRs like #543, and #551 as well as future torrent and non-torrent providers, as you could generally discern title information from the links and be able to quickly tell that episodes are there and in correct order.

Example of what Erai-raws would print with this change: 
`https://magnet:?xt=urn:btih:20BA9CF86D8ACFBE98EBC04D0F76E7177FE73BCF&dn=[Erai-raws] Naruto - 01 ~ 220 [480p][Multiple Subtitle]&tr=http://nyaa.tracker.wf:7777/announce&tr=http://anidex.moe:6969/announce&tr=udp://tracker.uw0.xyz:6969&tr=http://tracker.anirena.com:80/announce&tr=udp://open.stealth.si:80/announce&tr=http://tracker.acgnx.se/announce&tr=udp://tracker.opentrackr.org:1337/announce&tr=udp://tracker.coppersurfer.tk:6969/announce&tr=udp://exodus.desync.com:6969/announce`

EDIT: Updated to use `episode.url` instead of `episode.source().stream_url` for magnets so they aren't prefixed with `https://`